### PR TITLE
feat!: add support for minimum maintained hypotheses

### DIFF
--- a/src/tbp/monty/frameworks/models/evidence_matching/resampling_hypotheses_updater.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/resampling_hypotheses_updater.py
@@ -414,7 +414,9 @@ class ResamplingHypothesesUpdater:
 
         # Returns a selection of hypotheses to maintain/delete
         hypotheses_selection = tracker.select_hypotheses(
-            slope_threshold=self.evidence_slope_threshold, channel=input_channel
+            slope_threshold=self.evidence_slope_threshold,
+            min_maintained_hyps=2,  # required by gsg
+            channel=input_channel,
         )
 
         return (

--- a/src/tbp/monty/frameworks/utils/evidence_matching.py
+++ b/src/tbp/monty/frameworks/utils/evidence_matching.py
@@ -418,7 +418,7 @@ class EvidenceSlopeTracker:
             self.remove_hyp(np.arange(self.total_size(channel)), channel)
 
     def select_hypotheses(
-        self, slope_threshold: float, channel: str
+        self, slope_threshold: float, min_maintained_hyps: int, channel: str
     ) -> HypothesesSelection:
         """Returns a hypotheses selection given a slope threshold.
 
@@ -429,7 +429,12 @@ class EvidenceSlopeTracker:
         Args:
             slope_threshold: Minimum slope value to keep a removable (sufficiently old)
                 hypothesis.
+            min_maintained_hyps: Minimum number of hypotheses to maintain.
             channel: Name of the input channel.
+
+        Note that the parameter `min_maintained_hyps` overrides the `slope_threshold`
+        and the removable mask. These hypotheses will be maintained regardless of their
+        slopes and ages.
 
         Returns:
             A selection of hypotheses to maintain.
@@ -444,6 +449,29 @@ class EvidenceSlopeTracker:
         removable_mask = self.removable_indices_mask(channel)
 
         maintain_mask = (slopes >= slope_threshold) | (~removable_mask)
+
+        # Ensure at least `min_maintained_hyps` are maintained.
+        # The needed hypotheses are chosen based on their slopes (i.e. high slopes
+        # first)
+        num_maintained_hyps = int(maintain_mask.sum())
+        num_needed_hyps = max(
+            0,
+            min(min_maintained_hyps, self.total_size(channel)) - num_maintained_hyps,
+        )
+        if num_needed_hyps > 0:
+            cand_idx = np.where(~maintain_mask)[0]
+
+            # Use all available hyps. No sorting here.
+            if cand_idx.size == num_needed_hyps:
+                maintain_mask[cand_idx] = True
+
+            # Use hyps with the highest slopes.
+            else:
+                cand_scores = np.nan_to_num(slopes[cand_idx], nan=-np.inf)
+                topk_ix = np.argpartition(cand_scores, num_needed_hyps)[
+                    -num_needed_hyps:
+                ]
+                maintain_mask[cand_idx[topk_ix]] = True
 
         return HypothesesSelection(maintain_mask)
 

--- a/src/tbp/monty/frameworks/utils/evidence_matching.py
+++ b/src/tbp/monty/frameworks/utils/evidence_matching.py
@@ -433,7 +433,7 @@ class EvidenceSlopeTracker:
             channel: Name of the input channel.
 
         Note that the parameter `min_maintained_hyps` overrides the `slope_threshold`
-        and the removable mask. These hypotheses will be maintained regardless of their
+        and the removable mask. These hypotheses will be maintained in spite of their
         slopes and ages.
 
         Returns:

--- a/tests/unit/frameworks/utils/evidence_matching_test.py
+++ b/tests/unit/frameworks/utils/evidence_matching_test.py
@@ -309,6 +309,32 @@ class EvidenceSlopeTrackerTest(unittest.TestCase):
         np.testing.assert_array_equal(selection.maintain_mask, expected_keep_mask)
         np.testing.assert_array_equal(selection.remove_mask, expected_remove_mask)
 
+    def test_select_hypotheses_keeps_min_maintained(self) -> None:
+        """Test that `min_maintained_hyps` adds only as many highest-slope hyps."""
+        self.tracker.add_hyp(5, self.channel)
+
+        # slopes are [1, 0.5, 0, -1, -0.5]
+        self.tracker.update(np.array([1.0, 1.0, 1.0, 3.0, 2.0]), self.channel)
+        self.tracker.update(np.array([2.0, 1.5, 1.0, 2.0, 1.5]), self.channel)
+        self.tracker.update(np.array([3.0, 2.0, 1.0, 1.0, 1.0]), self.channel)
+
+        # Make only the last hypotheses non-removable
+        self.tracker.hyp_age[self.channel] = np.array([10, 10, 10, 10, 0], dtype=int)
+
+        selection = self.tracker.select_hypotheses(
+            slope_threshold=+np.inf,  # nothing passes by slope
+            min_maintained_hyps=2,  # should end with exactly two kept
+            channel=self.channel,
+        )
+
+        # Id 4 is maintained because of it's age,
+        # Id 0 is maintained because we need one more hypothesis (chosen based on slope)
+        expected_keep_mask = np.array([True, False, False, False, True], dtype=bool)
+        expected_remove_mask = ~expected_keep_mask
+
+        np.testing.assert_array_equal(selection.maintain_mask, expected_keep_mask)
+        np.testing.assert_array_equal(selection.remove_mask, expected_remove_mask)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/frameworks/utils/evidence_matching_test.py
+++ b/tests/unit/frameworks/utils/evidence_matching_test.py
@@ -291,7 +291,9 @@ class EvidenceSlopeTrackerTest(unittest.TestCase):
         self.tracker.hyp_age[self.channel] = np.array([3, 3, 3, 1], dtype=int)
 
         selection = self.tracker.select_hypotheses(
-            slope_threshold=-0.5, channel=self.channel
+            slope_threshold=-0.5,
+            min_maintained_hyps=0,
+            channel=self.channel,
         )
 
         # 0,1 have higher slopes, 3 is too young


### PR DESCRIPTION
This PR introduces a [new parameter](https://github.com/thousandbrainsproject/tbp.monty/blob/fb515b242e1b66f3a8787f8d839b3c95f364fc9c/src/tbp/monty/frameworks/utils/evidence_matching.py?plain=1#L432) in the `EvidenceSlopeTracker.select_hypotheses` function. This new parameter allows us to choose a minimum number of maintained hypotheses during the [deletion step](https://github.com/thousandbrainsproject/tbp.monty/blob/fb515b242e1b66f3a8787f8d839b3c95f364fc9c/src/tbp/monty/frameworks/models/evidence_matching/resampling_hypotheses_updater.py?plain=1#L416-L420).

Note that this is added because the GSG expects a hypothesis space to have multiple hypotheses (at least 2). In the future, we may choose to change the GSG behavior to disregard hypothesis spaces with less than 2 hypotheses.

There are two main commits:
- [3f2b9ce77db7](https://github.com/thousandbrainsproject/feat.dynamic_resizing/commit/3f2b9ce77db71b5318ec69d5fd7027950d0713c8) adds the main logic of ensuring the requested number of hypotheses are maintained.
- [fb515b242e1b](https://github.com/thousandbrainsproject/feat.dynamic_resizing/commit/fb515b242e1b66f3a8787f8d839b3c95f364fc9c) adds a new unit test for this change.